### PR TITLE
Finalização dos endpoints de Product

### DIFF
--- a/src/main/java/com/emanueldev/sample_shop/controllers/ProductController.java
+++ b/src/main/java/com/emanueldev/sample_shop/controllers/ProductController.java
@@ -1,28 +1,42 @@
 package com.emanueldev.sample_shop.controllers;
 
 import com.emanueldev.sample_shop.domain.dtos.request.ProductRequestDTO;
+import com.emanueldev.sample_shop.domain.dtos.response.PaginatedProductResponseDTO;
 import com.emanueldev.sample_shop.domain.dtos.response.ProductResponseDTO;
 import com.emanueldev.sample_shop.domain.mappers.ProductMapper;
 import com.emanueldev.sample_shop.model.Product;
-import com.emanueldev.sample_shop.services.CreateProductUseCase;
+import com.emanueldev.sample_shop.services.*;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/products")
 public class ProductController {
 
     private final CreateProductUseCase createProductUseCase;
+    private final GetProductByIdUseCase getProductByIdUseCase;
+    private final GetAllProductsUseCase getAllProductsUseCase;
+    private final DeleteProductUseCase deleteProductUseCase;
+    private final UpdateProductUseCase updateProductUseCase;
 
     public ProductController(
-            CreateProductUseCase createProductUseCase
+            CreateProductUseCase createProductUseCase,
+            GetProductByIdUseCase getProductByIdUseCase,
+            GetAllProductsUseCase getAllProductsUseCase,
+            DeleteProductUseCase deleteProductUseCase,
+            UpdateProductUseCase updateProductUseCase
     ) {
         this.createProductUseCase = createProductUseCase;
+        this.getProductByIdUseCase = getProductByIdUseCase;
+        this.getAllProductsUseCase = getAllProductsUseCase;
+        this.deleteProductUseCase = deleteProductUseCase;
+        this.updateProductUseCase = updateProductUseCase;
     }
 
     @PostMapping
@@ -33,5 +47,50 @@ public class ProductController {
                 .mappingFromEntityToProductResponseDto(product);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProductResponseDTO> getById(@PathVariable("id") UUID id) {
+        Product product = getProductByIdUseCase.execute(id);
+
+        ProductResponseDTO response = ProductMapper
+                .mappingFromEntityToProductResponseDto(product);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<PaginatedProductResponseDTO> getAll(
+            @RequestParam(defaultValue = "0") @PositiveOrZero final Integer pageNumber,
+            @RequestParam(defaultValue = "5") @PositiveOrZero final Integer pageSize
+    ) {
+        Page<Product> productPage = getAllProductsUseCase.execute(pageNumber, pageSize);
+
+        PaginatedProductResponseDTO response = ProductMapper
+                .mappingFromProductPageToPaginatedProductDTO(productPage);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(
+            @PathVariable("id") UUID id
+    ){
+        deleteProductUseCase.execute(id);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ProductResponseDTO> update(
+            @PathVariable("id") UUID id,
+            @RequestBody @Valid ProductRequestDTO productRequestDTO
+    ) {
+        Product product = updateProductUseCase.execute(id, productRequestDTO);
+
+        ProductResponseDTO response = ProductMapper
+                .mappingFromEntityToProductResponseDto(product);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/emanueldev/sample_shop/domain/dtos/response/PaginatedProductResponseDTO.java
+++ b/src/main/java/com/emanueldev/sample_shop/domain/dtos/response/PaginatedProductResponseDTO.java
@@ -1,0 +1,20 @@
+package com.emanueldev.sample_shop.domain.dtos.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@Builder
+public class PaginatedProductResponseDTO {
+
+    List<ProductResponseDTO> products;
+    int current_page;
+    long total_items;
+    int total_pages;
+}

--- a/src/main/java/com/emanueldev/sample_shop/domain/mappers/ProductMapper.java
+++ b/src/main/java/com/emanueldev/sample_shop/domain/mappers/ProductMapper.java
@@ -1,8 +1,12 @@
 package com.emanueldev.sample_shop.domain.mappers;
 
 import com.emanueldev.sample_shop.domain.dtos.request.ProductRequestDTO;
+import com.emanueldev.sample_shop.domain.dtos.response.PaginatedProductResponseDTO;
 import com.emanueldev.sample_shop.domain.dtos.response.ProductResponseDTO;
 import com.emanueldev.sample_shop.model.Product;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
 
 
 public class ProductMapper {
@@ -26,5 +30,28 @@ public class ProductMapper {
                 .price(data.getPrice())
                 .stockQuantity(data.getStockQuantity())
                 .build();
+    }
+
+    public static PaginatedProductResponseDTO mappingFromProductPageToPaginatedProductDTO(Page<Product> productPage){
+        List<ProductResponseDTO> listProductResponseDTO = productPage
+                .getContent()
+                .stream()
+                .map(ProductMapper::mappingFromEntityToProductResponseDto)
+                .toList();
+
+        return PaginatedProductResponseDTO
+                .builder()
+                .products(listProductResponseDTO)
+                .current_page(productPage.getNumber())
+                .total_items(productPage.getTotalElements())
+                .total_pages(productPage.getTotalPages())
+                .build();
+    }
+
+    public static void mappingProductRequestDTOToExistentProductEntity(ProductRequestDTO requestDTO, Product product){
+        product.setName(requestDTO.getName());
+        product.setDescription(requestDTO.getDescription());
+        product.setPrice(requestDTO.getPrice());
+        product.setStockQuantity(requestDTO.getStockQuantity());
     }
 }

--- a/src/main/java/com/emanueldev/sample_shop/exceptions/HttpNotFoundException.java
+++ b/src/main/java/com/emanueldev/sample_shop/exceptions/HttpNotFoundException.java
@@ -1,0 +1,7 @@
+package com.emanueldev.sample_shop.exceptions;
+
+public class HttpNotFoundException extends RuntimeException {
+    public HttpNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/emanueldev/sample_shop/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/emanueldev/sample_shop/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.emanueldev.sample_shop.handler;
 
 import com.emanueldev.sample_shop.exceptions.ApplicationException;
 import com.emanueldev.sample_shop.exceptions.HttpBadRequestException;
+import com.emanueldev.sample_shop.exceptions.HttpNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -21,13 +23,26 @@ public class GlobalExceptionHandler {
                 exception.getMessage());
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(response.getCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(response);
+    }
+
+    @ExceptionHandler(HttpNotFoundException.class)
+    public ResponseEntity<ApplicationException> handleHttpNotFoundException(HttpServletRequest request, HttpNotFoundException exception) {
+        ApplicationException response = new ApplicationException(
+                request,
+                HttpStatus.NOT_FOUND,
+                exception.getMessage());
+
+        return ResponseEntity
+                .status(response.getCode())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApplicationException> methodArgumentNotValidException(
+    public ResponseEntity<ApplicationException> handleMethodArgumentNotValidException(
             HttpServletRequest request,
             MethodArgumentNotValidException ex) {
         return ResponseEntity
@@ -39,6 +54,22 @@ public class GlobalExceptionHandler {
                                 HttpStatus.UNPROCESSABLE_ENTITY,
                                 "Validation error",
                                 ex.getBindingResult()
+                        )
+                );
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApplicationException> handleMethodArgumentTypeMismatchException(
+            HttpServletRequest request,
+            MethodArgumentTypeMismatchException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(
+                        new ApplicationException(
+                                request,
+                                HttpStatus.UNPROCESSABLE_ENTITY,
+                                ex.getMessage()
                         )
                 );
     }

--- a/src/main/java/com/emanueldev/sample_shop/model/Product.java
+++ b/src/main/java/com/emanueldev/sample_shop/model/Product.java
@@ -1,9 +1,7 @@
 package com.emanueldev.sample_shop.model;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -11,6 +9,8 @@ import java.util.UUID;
 @Setter
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "tb_products")
 public class Product {

--- a/src/main/java/com/emanueldev/sample_shop/repositories/ProductRepository.java
+++ b/src/main/java/com/emanueldev/sample_shop/repositories/ProductRepository.java
@@ -2,10 +2,12 @@ package com.emanueldev.sample_shop.repositories;
 
 import com.emanueldev.sample_shop.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductRepository extends JpaRepository<Product, UUID> {
-
-    boolean existsByName(String name);
+    @Query
+    Optional<Product> findByName(String name);
 }

--- a/src/main/java/com/emanueldev/sample_shop/services/CreateProductUseCase.java
+++ b/src/main/java/com/emanueldev/sample_shop/services/CreateProductUseCase.java
@@ -21,7 +21,9 @@ public class CreateProductUseCase {
     @Transactional
     public Product execute(ProductRequestDTO data) {
 
-        boolean productWithSameNameAlreadyExists = productRepository.existsByName(data.getName());
+        boolean productWithSameNameAlreadyExists = productRepository
+                .findByName(data.getName())
+                .isPresent();
 
         if(productWithSameNameAlreadyExists) {
             throw new HttpBadRequestException(ProductExceptionMessageUtils.PRODUCT_WITH_SAME_NAME_ALREADY_EXISTS);

--- a/src/main/java/com/emanueldev/sample_shop/services/DeleteProductUseCase.java
+++ b/src/main/java/com/emanueldev/sample_shop/services/DeleteProductUseCase.java
@@ -1,0 +1,35 @@
+package com.emanueldev.sample_shop.services;
+
+import com.emanueldev.sample_shop.exceptions.HttpNotFoundException;
+import com.emanueldev.sample_shop.model.Product;
+import com.emanueldev.sample_shop.repositories.ProductRepository;
+import com.emanueldev.sample_shop.utils.ProductExceptionMessageUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class DeleteProductUseCase {
+
+    private final ProductRepository productRepository;
+
+    public DeleteProductUseCase(
+            ProductRepository productRepository
+    ){
+        this.productRepository = productRepository;
+    }
+
+    @Transactional
+    public void execute(UUID id) {
+        Product product = this.productRepository
+                .findById(id)
+                .orElseThrow(() ->
+                    new HttpNotFoundException(
+                            ProductExceptionMessageUtils.PRODUCT_NOT_FOUND)
+                );
+
+        productRepository.delete(product);
+    }
+}

--- a/src/main/java/com/emanueldev/sample_shop/services/GetAllProductsUseCase.java
+++ b/src/main/java/com/emanueldev/sample_shop/services/GetAllProductsUseCase.java
@@ -1,0 +1,25 @@
+package com.emanueldev.sample_shop.services;
+
+import com.emanueldev.sample_shop.model.Product;
+import com.emanueldev.sample_shop.repositories.ProductRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GetAllProductsUseCase {
+
+    private final ProductRepository productRepository;
+
+    public GetAllProductsUseCase(ProductRepository productRepository){
+        this.productRepository = productRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Product> execute(Integer pageNumber, Integer size) {
+        return this.productRepository
+                .findAll(PageRequest.of(pageNumber, size));
+    }
+
+}

--- a/src/main/java/com/emanueldev/sample_shop/services/GetProductByIdUseCase.java
+++ b/src/main/java/com/emanueldev/sample_shop/services/GetProductByIdUseCase.java
@@ -1,0 +1,29 @@
+package com.emanueldev.sample_shop.services;
+
+import com.emanueldev.sample_shop.exceptions.HttpNotFoundException;
+import com.emanueldev.sample_shop.model.Product;
+import com.emanueldev.sample_shop.repositories.ProductRepository;
+import com.emanueldev.sample_shop.utils.ProductExceptionMessageUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+public class GetProductByIdUseCase {
+
+    private final ProductRepository productRepository;
+
+    public GetProductByIdUseCase(ProductRepository productRepository){
+        this.productRepository = productRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Product execute(UUID id) {
+        return productRepository.findById(id)
+                .orElseThrow(() ->
+                        new HttpNotFoundException(
+                                ProductExceptionMessageUtils
+                                        .PRODUCT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/emanueldev/sample_shop/utils/ProductExceptionMessageUtils.java
+++ b/src/main/java/com/emanueldev/sample_shop/utils/ProductExceptionMessageUtils.java
@@ -2,4 +2,5 @@ package com.emanueldev.sample_shop.utils;
 
 public class ProductExceptionMessageUtils {
     public static final String PRODUCT_WITH_SAME_NAME_ALREADY_EXISTS = "A product with same name already exists.";
+    public static final String PRODUCT_NOT_FOUND = "Product Not Found.";
 }


### PR DESCRIPTION
Esta PR tem por finalidade adicionar os demais endpoints da entidade produtos. Entre as adições, estão:

- Casos de uso restantes: Adicionados casos de uso para busca pelo id, busca por todos os produtos (suporta paginação), atualização e deleção de produtos, tendo respectivas validações para caso o produto não exista ou haja a tentativa de atualizar um produto com o nome de outro já existente.
- Adição de novo método no GlobalExceptionHandler: Adicionado método para capturar a ArgumentTypeMismatchException no GlobalExceptionHandler. Isto é particularmente útil quando o parsing do UUID na camada da controller falha (como no caso do usuário passar um UUID inválido).
- Adição de novos métodos no mapper: Adicionados métodos no mapper para mapear do tipo Page<Product> para o tipo PaginatedProductResponseDTO, bem como um método para transferir os dados do dto para um produto já existente (quando ha a tentativa de atualização.)
- Correção do construtor do product model: Por não possuir um construtor com todos os argumentos, havia uma falha onde não era possível lidar com novas instâncias do product.
- Adição da Exception para quando a busca retorna null: Adicionada HttpNotFoundException para lidar com casos onde uma busca pelo produto, ou demais entidades, falhe.