### PR TITLE
Feat/products

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,13 +40,13 @@ services:
     networks:
       - ss-network
 
-#  grafana:
-#    container_name: grafana
-#    image: grafana/grafana:latest
-#    ports:
-#      - "3000:3000"
-#    networks:
-#      - ss-network
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    networks:
+      - ss-network
 
 
 networks:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,32 @@
+server:
+  servlet:
+    context-path: /api/v1
+  port: ${APP_PORT}
+
+spring:
+  application:
+    name: sample-shop
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+management:
+  endpoints:
+    enabled-by-default: true
+    web:
+      exposure:
+        include: 'health,prometheus'
+    endpoint:
+      health:
+        enabled: true
+        show-details: always
+      prometheus:
+        enabled: true

--- a/src/test/java/com/emanueldev/sample_shop/unit/product/controllers/ProductControllerTest.java
+++ b/src/test/java/com/emanueldev/sample_shop/unit/product/controllers/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package com.emanueldev.sample_shop.unit.product.controllers;
 
+import com.emanueldev.sample_shop.controllers.ProductController;
 import com.emanueldev.sample_shop.domain.products.dto.request.ProductRequestDTO;
 import com.emanueldev.sample_shop.domain.products.dto.response.PaginatedProductResponseDTO;
 import com.emanueldev.sample_shop.domain.products.dto.response.ProductResponseDTO;
@@ -34,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.hamcrest.Matchers.is;
 
-@WebMvcTest
+@WebMvcTest(controllers = { ProductController.class})
 public class ProductControllerTest {
 
     @Autowired


### PR DESCRIPTION
Esta PR tem por objetivo adicionar uma correção para o teste unitário para a controller da entidade de produtos. Anteriormente, ao tentar rodar os testes desta controller ela acabava tentando subir os beans da OrderController, o que consequentemente causava um erro, dado que os únicos Beans que ela deve instanciar são os pertinentes a ProductController. Além desta correção, descomentei o grafana para posteriores testes e criação de dashboards da aplicação. Ademais, adicionei um profile para o ambiente de produção com configurações diferentes (como não exibir as queries que estão sendo rodadas no banco).